### PR TITLE
API.cue fixes

### DIFF
--- a/greymatter.io/api/api.cue
+++ b/greymatter.io/api/api.cue
@@ -326,7 +326,7 @@ import (
 	gm_ensure_variables?:    http.#EnsureVariablesConfig
 	gm_keycloak?:            http.#GmJwtKeycloakConfig
 	gm_oauth?:               http.#OauthConfig
-	gm_oidc_authenticaiton?: http.#AuthenticationConfig
+	gm_oidc_authentication?: http.#AuthenticationConfig
 	gm_oidc_validation?:     http.#ValidationConfig
 }
 

--- a/greymatter.io/api/api.cue
+++ b/greymatter.io/api/api.cue
@@ -12,6 +12,8 @@ import (
 	cluster_key:  string
 	zone_key:     string
 	require_tls?: bool
+	lb_policy?: string 
+	dns_type?: string
 	instances?: [...#Instance]
 	health_checks?: [...#HealthCheck]
 	outlier_detection?:     #OutlierDetection


### PR DESCRIPTION
This adds two fields to make the cue match the [fields in gm-control](https://github.com/greymatter-io/gm-control/blob/main/control-api/api/cluster.go#L58) for a cluster object