### PR TITLE
multi word filter names must use - not _

### DIFF
--- a/greymatter.io/api/api.cue
+++ b/greymatter.io/api/api.cue
@@ -318,6 +318,8 @@ import (
 }
 
 #HTTPFilters: {
+        //Important: If your filter is multiple words, make it a quoted field
+	//so that gm-control can pick up the configuration 
 	gm_metrics?:               http.#MetricsConfig
 	gm_impersonation?:         http.#ImpersonationConfig
 	gm_inheaders?:             http.#InheadersConfig

--- a/greymatter.io/api/api.cue
+++ b/greymatter.io/api/api.cue
@@ -318,16 +318,16 @@ import (
 }
 
 #HTTPFilters: {
-	gm_metrics?:             http.#MetricsConfig
-	gm_impersonation?:       http.#ImpersonationConfig
-	gm_inheaders?:           http.#InheadersConfig
-	gm_listauth?:            http.#ListAuthConfig
-	gm_observables?:         http.#ObservablesConfig
-	gm_ensure_variables?:    http.#EnsureVariablesConfig
-	gm_keycloak?:            http.#GmJwtKeycloakConfig
-	gm_oauth?:               http.#OauthConfig
-	gm_oidc_authentication?: http.#AuthenticationConfig
-	gm_oidc_validation?:     http.#ValidationConfig
+	gm_metrics?:               http.#MetricsConfig
+	gm_impersonation?:         http.#ImpersonationConfig
+	gm_inheaders?:             http.#InheadersConfig
+	gm_listauth?:              http.#ListAuthConfig
+	gm_observables?:           http.#ObservablesConfig
+	"gm_ensure-variables?":    http.#EnsureVariablesConfig
+	gm_keycloak?:              http.#GmJwtKeycloakConfig
+	gm_oauth?:                 http.#OauthConfig
+	"gm_oidc_authentication"?: http.#AuthenticationConfig
+	"gm_oidc_validation"?:     http.#ValidationConfig
 	...
 }
 

--- a/greymatter.io/api/api.cue
+++ b/greymatter.io/api/api.cue
@@ -323,7 +323,7 @@ import (
 	gm_inheaders?:             http.#InheadersConfig
 	gm_listauth?:              http.#ListAuthConfig
 	gm_observables?:           http.#ObservablesConfig
-	"gm_ensure-variables?":    http.#EnsureVariablesConfig
+	"gm_ensure-variables"?:    http.#EnsureVariablesConfig
 	gm_keycloak?:              http.#GmJwtKeycloakConfig
 	gm_oauth?:                 http.#OauthConfig
 	"gm_oidc_authentication"?: http.#AuthenticationConfig

--- a/greymatter.io/api/api.cue
+++ b/greymatter.io/api/api.cue
@@ -326,8 +326,8 @@ import (
 	"gm_ensure-variables"?:    http.#EnsureVariablesConfig
 	gm_keycloak?:              http.#GmJwtKeycloakConfig
 	gm_oauth?:                 http.#OauthConfig
-	"gm_oidc_authentication"?: http.#AuthenticationConfig
-	"gm_oidc_validation"?:     http.#ValidationConfig
+	"gm_oidc-authentication"?: http.#AuthenticationConfig
+	"gm_oidc-validation"?:     http.#ValidationConfig
 	...
 }
 


### PR DESCRIPTION
Noticed this is a bug with our current cue definitions of multi word filters. If you use an `_` in the name to separate the name of the filter (not the `_` immediately following `gm`), even though the filter does show up in the dashboard, it does not get applied by control to the mesh. 